### PR TITLE
Make s3md5 work on OS X

### DIFF
--- a/s3md5
+++ b/s3md5
@@ -151,13 +151,23 @@ cleanup() {
    $RM_BIN "$BIN_FILE"
 }
 
+if [ "$(uname)" == "Darwin" ]; then
+	IS_OSX=1
+else
+	IS_OSX=0
+fi
+
 ROOT_PATH=`root_path`
 APP=`basename $0`
 
 ECHO_BIN=$(which echo)
 RM_BIN="$(which rm) -rf"
 DD_BIN=$(which dd)
-MD5_BIN=$(which md5sum)
+if [ "$IS_OSX" -eq 0 ]; then
+	MD5_BIN=$(which md5sum)
+else
+	MD5_BIN=$(which md5)
+fi
 CUT_BIN=$(which cut)
 GREP_BIN=$(which grep)
 CAT_BIN=$(which cat)
@@ -224,7 +234,7 @@ i=0
 while true; do
    sum=`$DD_BIN bs=1024k count=$SIZE skip=$i if="$FILE" 2> "$ERROR_FILE" | $MD5_BIN | $CUT_BIN -d' ' -f1`
 
-   if $GREP_BIN -q "0 bytes (0 B) copied" "$ERROR_FILE"; then
+   if $GREP_BIN -q "^0 bytes " "$ERROR_FILE"; then
       # break this loop if 0 bytes read
       if [ $DEBUG -eq 1 ]; then
          $ECHO_BIN "END"
@@ -262,7 +272,12 @@ fi
 $CAT_BIN "$SUM_FILE" | $AWK_BIN '{print $1}' | while read MD5; do $ECHO_BIN $MD5 | $XXD_BIN -r -p >> "$BIN_FILE"; done
 
 # Calculate MD5 sum of this binary file
-s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f1`
+if [ "$IS_OSX" -eq 0 ]; then
+	s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f1`
+else
+	s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f4`
+fi
+
 if [ $DEBUG -eq 1 ]; then
    $ECHO_BIN -n "Etag/S3 MD5 Sum : "
 fi

--- a/s3md5
+++ b/s3md5
@@ -152,9 +152,9 @@ cleanup() {
 }
 
 if [ "$(uname)" == "Darwin" ]; then
-	IS_OSX=1
+  IS_OSX=1
 else
-	IS_OSX=0
+  IS_OSX=0
 fi
 
 ROOT_PATH=`root_path`
@@ -164,9 +164,9 @@ ECHO_BIN=$(which echo)
 RM_BIN="$(which rm) -f"
 DD_BIN=$(which dd)
 if [ "$IS_OSX" -eq 0 ]; then
-	MD5_BIN=$(which md5sum)
+  MD5_BIN=$(which md5sum)
 else
-	MD5_BIN=$(which md5)
+  MD5_BIN=$(which md5)
 fi
 CUT_BIN=$(which cut)
 GREP_BIN=$(which grep)
@@ -273,9 +273,9 @@ $CAT_BIN "$SUM_FILE" | $AWK_BIN '{print $1}' | while read MD5; do $ECHO_BIN $MD5
 
 # Calculate MD5 sum of this binary file
 if [ "$IS_OSX" -eq 0 ]; then
-	s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f1`
+  s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f1`
 else
-	s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f4`
+  s3sum=`$MD5_BIN "$BIN_FILE" | $CUT_BIN -d' ' -f4`
 fi
 
 if [ $DEBUG -eq 1 ]; then

--- a/s3md5
+++ b/s3md5
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with s3md5.  If not, see <http://www.gnu.org/licenses/>.
 
-VERSION='1.1'
+VERSION='1.2'
 DEBUG=0
 
 ##################################################################

--- a/s3md5
+++ b/s3md5
@@ -161,7 +161,7 @@ ROOT_PATH=`root_path`
 APP=`basename $0`
 
 ECHO_BIN=$(which echo)
-RM_BIN="$(which rm) -rf"
+RM_BIN="$(which rm) -f"
 DD_BIN=$(which dd)
 if [ "$IS_OSX" -eq 0 ]; then
 	MD5_BIN=$(which md5sum)


### PR DESCRIPTION
A couple of changes mostly around OS X having md5 not md5sum, and differences in output of the utilities invoked.

Note: changes not validated on Linux, please double-check!
